### PR TITLE
[feat/#31] 인기상품 api 추가, 전체 상품 조회 수정

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -211,6 +211,23 @@ app.get("/api/v1/search", async (req: Request, res: Response) => {
   }
 });
 
+app.get('/api/v1/popular', async (req: Request, res: Response) => {
+  const n = 5; // 상위 n개의 상품
+
+  try {
+    const popularProducts = await Product.findAll({
+      limit: n,
+      order: [['product_buy', 'DESC']],
+      attributes: ['product_name', 'product_price', 'product_buy', 'image_url']
+    });
+
+    res.status(200).json(popularProducts);
+  } catch (error) {
+    console.error(error);
+    res.status(500).send({ error: "Error retrieving popular products data" });
+  }
+});
+
 app.listen(port, () => console.log("Server is running at port 8080"));
 
 sequelize.sync();

--- a/index.ts
+++ b/index.ts
@@ -149,7 +149,7 @@ app.post('/api/v1/predict', upload.single('upload'), async (req: Request, res: R
 
 app.get("/api/v1/products", async (req: Request, res: Response) => {
   const page = Number(req.query.page) || 1; // 디폴트 값: 1
-  const limit = 5;
+  const limit = 8;
   const offset = (page - 1) * limit;
 
   try {
@@ -195,7 +195,11 @@ app.get("/api/v1/search", async (req: Request, res: Response) => {
   try {
     const lowerKeyword = keyword.toLowerCase();
     const products = await Product.findAll({
-      where: Sequelize.where(Sequelize.fn('lower', Sequelize.col('product_name')), 'LIKE', `%${lowerKeyword}%`),
+      where: Sequelize.where(
+        Sequelize.fn('lower', Sequelize.col('product_name')),
+        'LIKE',
+        `%${lowerKeyword}%`
+      ),
       attributes: ['product_name', 'product_price', 'product_stock', 'image_url'],
     });
 


### PR DESCRIPTION
- 전체 상품에서 많이 팔린 순서대로 상위 5개를 전달.

- 전체 상품 조회(products)에서 한 페이지 당 상품의 개수를 5에서 8로 변경