### PR TITLE
[feat/#37] node exporter, Slack alertmanager 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ config.json
 .DS_Store
 __pycache__
 shotping_flaksk/__pycache__/*
+alertmanager/alertmanager.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,12 @@ services:
       - '--collector.filesystem.ignored-mount-points=^/(sys|proc|dev|host|etc)($$|/)'
     ports:
       - 9100:9100
+  alertmanager:
+    image: prom/alertmanager
+    volumes:
+      - ./alertmanager:/etc/alertmanager
+    ports:
+      - 9093:9093
 volumes:
   prometheus_data: {}
   grafana_data: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     - RABBITMQ_DEFAULT_PASS=${RABBITMQ_DEFAULT_PASS}
     command: gunicorn -b :5000 app:app
   rabbitmq:
+    container_name: rabbitmq
     image: "rabbitmq:3-management"
     hostname: "rabbitmq"
     restart: unless-stopped # 컨테이너 종료시 (재시작여부) 종료 코드와 상관없이 컨테이너가 다시시작하지만 서비스가 중지되거나 제거되면 다시 시작을 중지
@@ -40,6 +41,7 @@ services:
       - 5672:5672 #rabbitmq AMQP 기본 포트 번호
       - 15672:15672 #Rabbitmq web
   celery:
+    container_name: celery
     build: ./shotping_flask
     volumes:
       - ./shotping_flask:/code
@@ -50,6 +52,7 @@ services:
     - RABBITMQ_DEFAULT_PASS=${RABBITMQ_DEFAULT_PASS}
     command: celery -A tasks worker --loglevel=info --pool=threads
   prometheus:
+    container_name: prometheus
     image: prom/prometheus
     volumes:
       - ./prometheus:/etc/prometheus
@@ -62,6 +65,7 @@ services:
     ports:
       - 9090:9090
   cadvisor:
+    container_name: cadvisor
     image: google/cadvisor
     volumes:
       - /:/rootfs:ro
@@ -71,6 +75,7 @@ services:
     ports:
       - 8081:8080
   grafana:
+    container_name: grafana
     image: grafana/grafana
     ports:
       - 3000:3000
@@ -79,6 +84,7 @@ services:
     depends_on:
       - prometheus
   node-exporter:
+    container_name: node-exporter
     image: prom/node-exporter
     volumes:
       - /proc:/host/proc:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,18 @@ services:
       - grafana_data:/var/lib/grafana
     depends_on:
       - prometheus
+  node-exporter:
+    image: prom/node-exporter
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - '--path.procfs=/host/proc'
+      - '--path.sysfs=/host/sys'
+      - '--collector.filesystem.ignored-mount-points=^/(sys|proc|dev|host|etc)($$|/)'
+    ports:
+      - 9100:9100
 volumes:
   prometheus_data: {}
   grafana_data: {}

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -4,9 +4,10 @@ global:
 
 alerting:
   alertmanagers:
-  - static_configs:
+  - scheme: http
+    static_configs:
     - targets:
-      - localhost:9093
+      - "alertmanager:9093"
 
 rule_files:
   - "rules.yml"
@@ -21,7 +22,6 @@ scrape_configs:
     - targets: ['prometheus:9090']
 
   - job_name: 'node-service'
-    metrics_path: '/metrics'
     static_configs:
       - targets: ['node-service:8080']
 

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -24,3 +24,7 @@ scrape_configs:
     metrics_path: '/metrics'
     static_configs:
       - targets: ['node-service:8080']
+
+  - job_name: node
+    static_configs:
+      - targets: ['node-exporter:9100']

--- a/prometheus/rules.yml
+++ b/prometheus/rules.yml
@@ -2,22 +2,22 @@ groups:
 - name: example
   rules:
   # cpu 사용량 80% 이상일 때
-  - alert: high_cpu_usage
-    expr: 100 - (avg by (instance) (irate(node_cpu_seconds_total{mode="idle"}[2m])) * 100) > 80
-    for: 2m
+  - alert: HighCPU
+    expr: 100 - (avg by(instance)(irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 1
+    for: 1m
     labels:
-      severity: warning
+      severity: critical
     annotations:
       summary: High CPU usage
-  
+
   # 메모리 사용량 80% 이상일 때
-  - alert: high_memory_usage
-    expr: node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes > (0.8 * node_memory_MemTotal_bytes)
-    for: 2m
+  - alert: HighMemory
+    expr: (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes * 100 > 1
+    for: 1m
     labels:
       severity: warning
     annotations:
-      summary: High memory usage
+      summary: High Memory usage
 
   # 0.5초 이상 요청 지연이 될 때
   - alert: high_request_latency
@@ -29,10 +29,10 @@ groups:
       summary: High request latency in node-service
 
   # 서비스가 다운됐을 때
-  - alert: service_down
+  - alert: InstanceDown
     expr: up == 0
-    for: 2m
+    for: 5m
     labels:
-      severity: page
+      severity: critical
     annotations:
-      summary: Service down
+      summary: Instance {{ $labels.instance }} down

--- a/prometheus/rules.yml
+++ b/prometheus/rules.yml
@@ -3,7 +3,7 @@ groups:
   rules:
   # cpu 사용량 80% 이상일 때
   - alert: HighCPU
-    expr: 100 - (avg by(instance)(irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 1
+    expr: 100 - (avg by(instance)(irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 80
     for: 1m
     labels:
       severity: critical
@@ -12,7 +12,7 @@ groups:
 
   # 메모리 사용량 80% 이상일 때
   - alert: HighMemory
-    expr: (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes * 100 > 1
+    expr: (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes * 100 > 80
     for: 1m
     labels:
       severity: warning
@@ -20,7 +20,7 @@ groups:
       summary: High Memory usage
 
   # 0.5초 이상 요청 지연이 될 때
-  - alert: high_request_latency
+  - alert: HighRequestLatency
     expr: job:request_latency_seconds:mean5m{job="node-service"} > 0.5
     for: 2m
     labels:


### PR DESCRIPTION
- grafana 대시보드 (cadvisor, http requests, node exporter) 생성

- docker 컨테이너 node exporter, alertmanager 추가
- alert rule (CPU 사용량 80% 이상, 메모리 사용량 80% 이상 등) 추가
- alertmanager.yml 파일에 slack_api_url이 외부에 노출되면 안되기 때문에 .gitignore 파일에 추가